### PR TITLE
Fix Swedish validation message encoding

### DIFF
--- a/src/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -108,7 +108,7 @@ namespace TimeTracker.Areas.Identity.Pages.Account
                 // Custom validation rule, only allow email addresses from softronic.se
                 if (!Input.Email.EndsWith("@softronic.se", StringComparison.OrdinalIgnoreCase))
                 {
-                    ModelState.AddModelError(string.Empty, "Endast e-postadresser fr�n softronic.se �r till�tna.");
+                    ModelState.AddModelError(string.Empty, "Endast e‑postadresser från softronic.se är tillåtna.");
                     return Page();
                 }
 


### PR DESCRIPTION
## Summary
- fix encoding of softronic.se email validation message in Register page
- ensure Register.cshtml.cs saved as UTF-8

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a700073a5483208de9c044884ab147