### PR TITLE
Add service unit tests for AI summary and SafeExecutor

### DIFF
--- a/tests/Services/AiSummaryStateServiceTests.cs
+++ b/tests/Services/AiSummaryStateServiceTests.cs
@@ -1,0 +1,41 @@
+using TimeTracker.Services;
+
+namespace TimeTracker.Tests.Services;
+
+[TestFixture]
+public class AiSummaryStateServiceTests
+{
+    private AiSummaryStateService _service;
+    private bool _eventFired;
+
+    [SetUp]
+    public void Setup()
+    {
+        _service = new AiSummaryStateService();
+        _eventFired = false;
+        _service.OnChange += () => _eventFired = true;
+    }
+
+    [Test]
+    public void SetAiSummary_UpdatesValueAndTriggersEvent()
+    {
+        var summary = "Test summary";
+
+        _service.SetAiSummary(summary);
+
+        Assert.That(_service.AiSummary, Is.EqualTo(summary));
+        Assert.That(_eventFired, Is.True);
+    }
+
+    [Test]
+    public void ClearAiSummary_ClearsValueAndTriggersEvent()
+    {
+        _service.SetAiSummary("something");
+        _eventFired = false;
+
+        _service.ClearAiSummary();
+
+        Assert.That(_service.AiSummary, Is.Empty);
+        Assert.That(_eventFired, Is.True);
+    }
+}

--- a/tests/Services/SafeExecutorTests.cs
+++ b/tests/Services/SafeExecutorTests.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel.DataAnnotations;
+using System.Data.Common;
+using System.Net;
+using Moq;
+using TimeTracker.Services;
+
+namespace TimeTracker.Tests.Services;
+
+[TestFixture]
+public class SafeExecutorTests
+{
+    private Mock<IErrorHandlingService> _errorHandlerMock = null!;
+    private SafeExecutor _executor = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _errorHandlerMock = new Mock<IErrorHandlingService>();
+        _executor = new SafeExecutor(_errorHandlerMock.Object);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_NoException_RunsAction()
+    {
+        bool ran = false;
+
+        await _executor.ExecuteAsync(() => { ran = true; return Task.CompletedTask; });
+
+        Assert.That(ran, Is.True);
+        _errorHandlerMock.VerifyNoOtherCalls();
+    }
+
+    private class TestDbException : DbException
+    {
+        public TestDbException(string message) : base(message) { }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DbException_CallsDatabaseHandler()
+    {
+        var ex = new TestDbException("db fail");
+
+        await _executor.ExecuteAsync(() => throw ex);
+
+        _errorHandlerMock.Verify(e => e.HandleDatabaseErrorAsync(ex, It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_HttpRequestException_CallsApiHandler()
+    {
+        HttpResponseMessage? captured = null;
+        _errorHandlerMock
+            .Setup(e => e.HandleApiErrorAsync(It.IsAny<HttpResponseMessage>(), It.IsAny<string>()))
+            .Callback<HttpResponseMessage, string>((resp, _) => captured = resp)
+            .Returns(Task.CompletedTask);
+
+        var httpEx = new HttpRequestException("not found", null, HttpStatusCode.NotFound);
+
+        await _executor.ExecuteAsync(() => throw httpEx);
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured!.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(captured.ReasonPhrase, Is.EqualTo("not found"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ValidationException_CallsValidationHandler()
+    {
+        var ex = new ValidationException("bad");
+
+        await _executor.ExecuteAsync(() => throw ex);
+
+        _errorHandlerMock.Verify(e => e.HandleValidationErrorAsync("bad", It.IsAny<string>(), It.IsAny<IDictionary<string, string[]>>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_GeneralException_CallsExceptionHandler()
+    {
+        var ex = new InvalidOperationException("oops");
+
+        await _executor.ExecuteAsync(() => throw ex);
+
+        _errorHandlerMock.Verify(e => e.HandleExceptionAsync(ex, It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteAsyncT_OnException_ReturnsFallback()
+    {
+        var result = await _executor.ExecuteAsync<int>(() => throw new Exception(), () => 42);
+
+        Assert.That(result, Is.EqualTo(42));
+        _errorHandlerMock.Verify(e => e.HandleExceptionAsync(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteListAsync_OnException_ReturnsEmptyList()
+    {
+        var list = await _executor.ExecuteListAsync<int>(() => throw new Exception());
+
+        Assert.That(list, Is.Empty);
+        _errorHandlerMock.Verify(e => e.HandleExceptionAsync(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for AiSummaryStateService to verify state updates
- add SafeExecutor tests covering success path and various exception cases

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b05b8522008320862f685c58a33891